### PR TITLE
PCI-1286. Record metrics of queues duration.

### DIFF
--- a/atc/db/dbfakes/fake_task_queue.go
+++ b/atc/db/dbfakes/fake_task_queue.go
@@ -15,6 +15,19 @@ type FakeTaskQueue struct {
 		arg1 string
 		arg2 lager.Logger
 	}
+	ElapsedStub        func(string) (int, error)
+	elapsedMutex       sync.RWMutex
+	elapsedArgsForCall []struct {
+		arg1 string
+	}
+	elapsedReturns struct {
+		result1 int
+		result2 error
+	}
+	elapsedReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
+	}
 	FindOrAppendStub        func(string, string, int, string, lager.Logger) (int, int, error)
 	findOrAppendMutex       sync.RWMutex
 	findOrAppendArgsForCall []struct {
@@ -111,6 +124,69 @@ func (fake *FakeTaskQueue) DequeueArgsForCall(i int) (string, lager.Logger) {
 	defer fake.dequeueMutex.RUnlock()
 	argsForCall := fake.dequeueArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeTaskQueue) Elapsed(arg1 string) (int, error) {
+	fake.elapsedMutex.Lock()
+	ret, specificReturn := fake.elapsedReturnsOnCall[len(fake.elapsedArgsForCall)]
+	fake.elapsedArgsForCall = append(fake.elapsedArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("Elapsed", []interface{}{arg1})
+	fake.elapsedMutex.Unlock()
+	if fake.ElapsedStub != nil {
+		return fake.ElapsedStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.elapsedReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTaskQueue) ElapsedCallCount() int {
+	fake.elapsedMutex.RLock()
+	defer fake.elapsedMutex.RUnlock()
+	return len(fake.elapsedArgsForCall)
+}
+
+func (fake *FakeTaskQueue) ElapsedCalls(stub func(string) (int, error)) {
+	fake.elapsedMutex.Lock()
+	defer fake.elapsedMutex.Unlock()
+	fake.ElapsedStub = stub
+}
+
+func (fake *FakeTaskQueue) ElapsedArgsForCall(i int) string {
+	fake.elapsedMutex.RLock()
+	defer fake.elapsedMutex.RUnlock()
+	argsForCall := fake.elapsedArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeTaskQueue) ElapsedReturns(result1 int, result2 error) {
+	fake.elapsedMutex.Lock()
+	defer fake.elapsedMutex.Unlock()
+	fake.ElapsedStub = nil
+	fake.elapsedReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTaskQueue) ElapsedReturnsOnCall(i int, result1 int, result2 error) {
+	fake.elapsedMutex.Lock()
+	defer fake.elapsedMutex.Unlock()
+	fake.ElapsedStub = nil
+	if fake.elapsedReturnsOnCall == nil {
+		fake.elapsedReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.elapsedReturnsOnCall[i] = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeTaskQueue) FindOrAppend(arg1 string, arg2 string, arg3 int, arg4 string, arg5 lager.Logger) (int, int, error) {
@@ -383,6 +459,8 @@ func (fake *FakeTaskQueue) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.dequeueMutex.RLock()
 	defer fake.dequeueMutex.RUnlock()
+	fake.elapsedMutex.RLock()
+	defer fake.elapsedMutex.RUnlock()
 	fake.findOrAppendMutex.RLock()
 	defer fake.findOrAppendMutex.RUnlock()
 	fake.findQueueMutex.RLock()

--- a/atc/db/task_queue_test.go
+++ b/atc/db/task_queue_test.go
@@ -241,4 +241,20 @@ var _ = Describe("TaskQueue", func() {
 			})
 		})
 	})
+
+	Describe("Elapsed", func() {
+		Context("when an element is added to the queue", func() {
+			Context("if the element is present", func() {
+				BeforeEach(func() {
+					_, err := dbConn.Exec("INSERT INTO tasks_queue(id, platform, team_id, worker_tag, insert_time) VALUES ('foo_id', 'foo_platform', 42, 'foo_tag', '2020-01-01 00:00:00.0+00')")
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It("the elapsed time in the queue in non-null", func() {
+					duration, err := taskQueue.Elapsed("foo_id")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(duration).To(BeNumerically(">", 0))
+				})
+			})
+		})
+	})
 })

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -667,3 +667,26 @@ func (event TaskQueue) Emit(logger lager.Logger) {
 		},
 	)
 }
+
+type QueueDuration struct {
+	Duration   int
+	Platform   string
+	Team       int
+	WorkerTags string
+}
+
+func (event QueueDuration) Emit(logger lager.Logger) {
+	emit(
+		logger.Session("tasks-queue"),
+		Event{
+			Name:  "queue duration",
+			Value: event.Duration,
+			State: EventStateOK,
+			Attributes: map[string]string{
+				"platform": event.Platform,
+				"team":     strconv.Itoa(event.Team),
+				"tags":     event.WorkerTags,
+			},
+		},
+	)
+}

--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -434,6 +434,17 @@ func decreaseActiveTasks(logger lager.Logger, w Worker) {
 }
 
 func dequeue(queue db.TaskQueue, taskId string, platform string, teamId int, workerTags string, logger lager.Logger) {
+	elapsed, err := queue.Elapsed(taskId)
+	if err != nil {
+		logger.Error("failed-to-evaluate-elapsed-time-in-queue", err)
+	}
+	metric.QueueDuration{
+		Duration:   elapsed,
+		Platform:   platform,
+		Team:       teamId,
+		WorkerTags: workerTags,
+	}.Emit(logger)
+
 	queue.Dequeue(taskId, logger)
 	qlen, err := queue.Length(taskId)
 	if err != nil {


### PR DESCRIPTION
Expose the elapsed time of the tasks in their queue, exporting them as Prometheus histograms.