### PR TITLE
go-concourse: connection client: give better error message to the end user

### DIFF
--- a/go-concourse/concourse/internal/connection.go
+++ b/go-concourse/concourse/internal/connection.go
@@ -200,7 +200,8 @@ func (connection *connection) populateResponse(response *http.Response, returnRe
 	}
 
 	if response.StatusCode == http.StatusForbidden {
-		return ErrForbidden
+		body, _ := io.ReadAll(response.Body)
+		return ForbiddenError{Reason: string(body)}
 	}
 
 	if response.StatusCode < 200 || response.StatusCode >= 300 {

--- a/go-concourse/concourse/internal/connection_test.go
+++ b/go-concourse/concourse/internal/connection_test.go
@@ -351,6 +351,34 @@ var _ = Describe("ATC Connection", func() {
 				})
 			})
 
+			Describe("403 response", func() {
+				BeforeEach(func() {
+					atcServer = ghttp.NewServer()
+
+					connection = NewConnection(atcServer.URL(), nil, tracing)
+
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("DELETE", "/api/v1/teams/main/pipelines/foo"),
+							ghttp.RespondWith(http.StatusForbidden, "problem"),
+						),
+					)
+				})
+
+				It("returns back ForbiddenError", func() {
+					err := connection.Send(Request{
+						RequestName: atc.DeletePipeline,
+						Params: rata.Params{
+							"pipeline_name": "foo",
+							"team_name":     atc.DefaultTeamName,
+						},
+					}, nil)
+					fe, ok := err.(ForbiddenError)
+					Expect(ok).To(BeTrue())
+					Expect(fe.Reason).To(Equal("problem"))
+				})
+			})
+
 			Describe("404 response", func() {
 				Context("when the response does not contain JSONAPI errors", func() {
 					BeforeEach(func() {


### PR DESCRIPTION
Almost every fly command (except e.g. set-pipeline) still uses the deprecated HTTP client called connection client.

If policy checker (e.g. OPA) does not allow the action the reason is never shown to the end user. The end user saw only `Forbidden` without the message of why it is forbidden. To see more details end user was required to run the command with `--verbose` or inspect the request in web UI.

Example: fly expose-pipeline (and many other commands) when OPA returned 200 and denied the action (correct json body).


What user saw before:

```
$ fly -t main expose-pipeline -p test
error: forbidden
```

What it sees now?

```
$ fly -t main expose-pipeline -p test
error: forbidden: policy check failed: 
 * <actual deny reason from OPA policy>
```