### PR TITLE
atc/api/policy-checker-handler: fix the logger session name

### DIFF
--- a/atc/api/policychecker/handler.go
+++ b/atc/api/policychecker/handler.go
@@ -34,7 +34,7 @@ type policyCheckingHandler struct {
 func (h policyCheckingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	acc := accessor.GetAccessor(r)
 
-	logger := h.logger.Session("policy-checker")
+	logger := h.logger.Session("handler")
 	result, err := h.policyChecker.Check(h.action, acc, r)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
now, I know why I had the `-handler` in the session name:

> {"timestamp":"2024-10-09T10:05:31.196402292Z","level":"error","source":"atc","message":"atc.policy-checker.policy-checker","data":{"error":"OPA server: connecting: Post \"http://localhost:8181/v1/data/concourse/decision\": dial tcp [::1]:8181: connect: connection refused","session":"134","user-msg":"policy-checker: unreachable or misconfigured"}}

note the msg: `atc.policy-checker.policy-checker`. The `atc.policy-checker` is already there. So the session name should just be `handler`.

With the proposed change we will see: `atc.policy-checker.handler`

This will also serve me as make-release branch given that we don't have a CHANGELOG... See our Gchat for more details.