### PR TITLE
os.Root.Symlink: normalize path separators on Windows

### DIFF
--- a/go-archive/tarfs/extract.go
+++ b/go-archive/tarfs/extract.go
@@ -128,7 +128,10 @@ func extractEntry(root *os.Root, header *tar.Header, input io.Reader, chown bool
 			}
 		}
 
-		err = root.Symlink(header.Linkname, filePath)
+		// Workaround for https://github.com/golang/go/issues/80073: os.Root.Symlink does
+		// not normalize path separators on Windows, so Unix-style tar link targets must
+		// be converted before creating the reparse point.
+		err = root.Symlink(filepath.FromSlash(header.Linkname), filePath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- workaround for https://github.com/golang/go/issues/80073

Same as Taylor opened upstream https://github.com/concourse/concourse/pull/9610 but with a comment.

Originally, I was adding the windows tests... but this will be done in a separate PR after discussion with @marco-m-pix4d 

I deployed this PR and tested. All e2e + e2e worker tests and acceptance tests are green.

Note that this goes into our release branch and will result in v8.2.5-pix4d **that will NOT be released upstream**.

See: https://github.com/concourse/concourse/issues/9609 the comment from Taylor

> I'm not making another patch for this though because I have patch fatigue with 8.2.x now 😓
