### PR TITLE
backport tests fixes

### DIFF
--- a/atc/db/pg_error.go
+++ b/atc/db/pg_error.go
@@ -1,0 +1,15 @@
+package db
+
+import (
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func isForeignKeyOrRestrictViolation(err error) bool {
+	pgErr, ok := err.(*pgconn.PgError)
+	if !ok {
+		return false
+	}
+
+	return pgErr.Code == pgerrcode.ForeignKeyViolation || pgErr.Code == pgerrcode.RestrictViolation
+}

--- a/atc/db/resource_cache_lifecycle.go
+++ b/atc/db/resource_cache_lifecycle.go
@@ -3,9 +3,6 @@ package db
 import (
 	"strings"
 
-	"github.com/jackc/pgerrcode"
-	"github.com/jackc/pgx/v5/pgconn"
-
 	"code.cloudfoundry.org/lager/v3"
 	sq "github.com/Masterminds/squirrel"
 )
@@ -146,7 +143,7 @@ func (f *resourceCacheLifecycle) CleanUpInvalidCaches(logger lager.Logger) error
 
 	rows, err := f.conn.Query(query, args...)
 	if err != nil {
-		if pgErr, ok := err.(*pgconn.PgError); ok && pgErr.Code == pgerrcode.ForeignKeyViolation {
+		if isForeignKeyOrRestrictViolation(err) {
 			// this can happen if a use or resource cache is created referencing the
 			// config; as the subqueries above are not atomic
 			return nil

--- a/atc/db/resource_cache_test.go
+++ b/atc/db/resource_cache_test.go
@@ -1,9 +1,10 @@
 package db_test
 
 import (
+	"time"
+
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
-	"time"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/concourse/concourse/atc"
@@ -58,7 +59,7 @@ var _ = Describe("ResourceCache", func() {
 			// ON DELETE RESTRICT from resource_cache_uses -> resource_caches
 			_, err = psql.Delete("resource_caches").Where(sq.Eq{"id": urc.ID()}).RunWith(dbConn).Exec()
 			Expect(err).To(HaveOccurred())
-			Expect(err.(*pgconn.PgError).Code).To(Equal(pgerrcode.ForeignKeyViolation))
+			Expect(err.(*pgconn.PgError).Code).To(BeElementOf(pgerrcode.ForeignKeyViolation, pgerrcode.RestrictViolation))
 		})
 
 		Context("when it already exists", func() {
@@ -114,7 +115,7 @@ var _ = Describe("ResourceCache", func() {
 			// ON DELETE RESTRICT from resource_cache_uses -> resource_caches
 			_, err = psql.Delete("resource_caches").Where(sq.Eq{"id": urc.ID()}).RunWith(dbConn).Exec()
 			Expect(err).To(HaveOccurred())
-			Expect(err.(*pgconn.PgError).Code).To(Equal(pgerrcode.ForeignKeyViolation))
+			Expect(err.(*pgconn.PgError).Code).To(BeElementOf(pgerrcode.ForeignKeyViolation, pgerrcode.RestrictViolation))
 		})
 	})
 })

--- a/atc/db/resource_config_factory.go
+++ b/atc/db/resource_config_factory.go
@@ -6,9 +6,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/jackc/pgerrcode"
-	"github.com/jackc/pgx/v5/pgconn"
-
 	sq "github.com/Masterminds/squirrel"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db/lock"
@@ -272,7 +269,7 @@ func (f *resourceConfigFactory) CleanUnreferencedConfigs(gracePeriod time.Durati
 		PlaceholderFormat(sq.Dollar).
 		RunWith(f.conn).Exec()
 	if err != nil {
-		if pgErr, ok := err.(*pgconn.PgError); ok && pgErr.Code == pgerrcode.ForeignKeyViolation {
+		if isForeignKeyOrRestrictViolation(err) {
 			// this can happen if a use or resource cache is created referencing the
 			// config; as the subqueries above are not atomic
 			return nil

--- a/go-archive/tarfs/extract.go
+++ b/go-archive/tarfs/extract.go
@@ -79,7 +79,7 @@ func extractEntry(root *os.Root, header *tar.Header, input io.Reader, chown bool
 	fileInfo := header.FileInfo()
 	fileMode := fileInfo.Mode()
 
-	err := root.MkdirAll(filepath.Dir(filePath), 0755)
+	err := RootMkdirAll(root, filepath.Dir(filePath), 0755)
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func extractEntry(root *os.Root, header *tar.Header, input io.Reader, chown bool
 		}
 
 	case tar.TypeDir:
-		err := root.MkdirAll(filePath, fileMode.Perm())
+		err := RootMkdirAll(root, filePath, fileMode.Perm())
 		if err != nil {
 			return err
 		}
@@ -231,4 +231,9 @@ func stripRoot(p string) string {
 	// Removes all leading forward and backwards slashes
 	p = strings.TrimLeft(p, `/\`)
 	return p
+}
+
+// Workaround for https://github.com/golang/go/issues/80308
+func RootMkdirAll(r *os.Root, path string, perm os.FileMode) error {
+	return r.MkdirAll(strings.TrimSuffix(path, "/"), perm)
 }

--- a/go-archive/tarfs/extract_test.go
+++ b/go-archive/tarfs/extract_test.go
@@ -185,7 +185,7 @@ var _ = Describe("ExtractEntry", func() {
 			By("creating the target of the hard link", func() {
 				root, err := os.OpenRoot(dest)
 				Expect(err).ToNot(HaveOccurred())
-				err = root.MkdirAll("absolute/path/", 0755)
+				err = tarfs.RootMkdirAll(root, "absolute/path/", 0755)
 				Expect(err).ToNot(HaveOccurred())
 				f, err := root.Create("absolute/path/file")
 				Expect(err).ToNot(HaveOccurred())

--- a/go-archive/zipfs/extract.go
+++ b/go-archive/zipfs/extract.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/klauspost/compress/zip"
 )
@@ -59,12 +60,12 @@ func extractZipArchiveFile(root *os.Root, file *zip.File, input io.Reader) error
 	fileInfo := file.FileInfo()
 
 	if fileInfo.IsDir() {
-		err := root.MkdirAll(filePath, fileInfo.Mode().Perm())
+		err := RootMkdirAll(root, filePath, fileInfo.Mode().Perm())
 		if err != nil {
 			return err
 		}
 	} else {
-		err := root.MkdirAll(filepath.Dir(filePath), 0755)
+		err := RootMkdirAll(root, filepath.Dir(filePath), 0755)
 		if err != nil {
 			return err
 		}
@@ -90,4 +91,9 @@ func extractZipArchiveFile(root *os.Root, file *zip.File, input io.Reader) error
 	}
 
 	return nil
+}
+
+// Workaround for https://github.com/golang/go/issues/80308
+func RootMkdirAll(r *os.Root, path string, perm os.FileMode) error {
+	return r.MkdirAll(strings.TrimSuffix(path, "/"), perm)
 }

--- a/worker/baggageclaim/volume/locker_test.go
+++ b/worker/baggageclaim/volume/locker_test.go
@@ -125,24 +125,19 @@ var _ = Describe("KeyedLock", func() {
 			})
 
 			It("cleans up locks that are no longer in use", func() {
-				// This test verifies that we don't leak memory by keeping unused locks
-
-				// Create and use 100 different locks
-				for i := range 100 {
-					key := fmt.Sprintf("temp-key-%d", i)
-					lockManager.Lock(key)
-					lockManager.Unlock(key)
-				}
-
-				// Now verify we can still create and use a new lock
-				lockAcquiredCh := make(chan struct{})
-				go func() {
-					lockManager.Lock("final-key")
-					close(lockAcquiredCh)
-					lockManager.Unlock("final-key")
-				}()
-
-				Eventually(lockAcquiredCh).Should(BeClosed())
+				By("creating a bunch of locks and immediatly releasing them", func() {
+					for i := range 100 {
+						key := fmt.Sprintf("temp-key-%d", i)
+						lockManager.Lock(key)
+						lockManager.Unlock(key)
+					}
+				})
+				By("verifying the locks no longer exist by catching the panic from Unlock()", func() {
+					for i := range 100 {
+						key := fmt.Sprintf("temp-key-%d", i)
+						Expect(func() { lockManager.Unlock(key) }).To(Panic())
+					}
+				})
 			})
 		})
 	})


### PR DESCRIPTION
backport tests fixes

Important to know: we need these 2 test fixes if we want to have our release pipeline green.

First, I synced our release branch with upstream, which picked up 1 fix: https://github.com/Pix4D/concourse/commit/570430859b70a99fff9a4feef582221cabac5199
Upstream, they also backported this to the release branch.

Secondly, I cherry-picked https://github.com/concourse/concourse/commit/4b88b05419b0ba0039b1b88fb092977346b75042 which never arrived on release branch upstream, but I have no clue how or why their tests in the release branch are passing. Maybe they don't run these tests anymore in release branch? 

Anyway, if we want to have concourse-fork-release pipeline green, we need these tests... both are already on master since I synced the fork on Friday.
