### PR TITLE
Fix absolute symlink test on Windows

### DIFF
--- a/go-archive/tarfs/extract_test.go
+++ b/go-archive/tarfs/extract_test.go
@@ -230,7 +230,9 @@ var _ = Describe("ExtractEntry", func() {
 
 			l, err := os.Readlink(filepath.Join(dest, "abs"))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(l).To(Equal(header.Linkname))
+			// Windows returns symlink targets with native separators; normalize
+			// them to the slash-separated form stored in tar headers.
+			Expect(filepath.ToSlash(l)).To(Equal(header.Linkname))
 		})
 
 		It("returns a BreakoutErr when a symlink points outside the destination", func() {


### PR DESCRIPTION
Fix absolute symlink test on Windows

- normalize Windows symlink separators before comparing them with the slash-separated tar header path.

The go-archive tests were always running only on Linux (even though most of the actual code is exercised on Windows). If you run it on Windows, this test `does not modify absolute paths"` would fail because: `"/absolute/path/file"` would not match `"\\absolute\\path\\file"`

The same PR will be proposed upstream.

Related to: https://github.com/Pix4D/ci-for-concourse/pull/59