### PR TITLE
pci-4898 goarchive tarfs regression tests

### DIFF
--- a/go-archive/tarfs/extract_test.go
+++ b/go-archive/tarfs/extract_test.go
@@ -64,6 +64,12 @@ var _ = Describe("Extract", func() {
 			Link: "/some-file",
 			Mode: 0755,
 		},
+		{
+			// Relative dir symlink: forward-slash targets were unreadable and broke robocopy on Windows (#9609).
+			Name: "./symlink-dir/relative-dir-symlink",
+			Link: "../nonempty-dir",
+			Mode: 0755,
+		},
 	}
 
 	BeforeEach(func() {
@@ -118,16 +124,18 @@ var _ = Describe("Extract", func() {
 
 		Expect(emptyDirInfo.IsDir()).To(BeTrue())
 
-		target, err := os.Readlink(filepath.Join(extractionDest, "some-symlink"))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(target).To(Equal("some-file"))
-
-		symlinkInfo, err := os.Lstat(filepath.Join(extractionDest, "some-symlink"))
-		Expect(err).NotTo(HaveOccurred())
-
-		if runtime.GOOS != "windows" {
-			Expect(symlinkInfo.Mode() & 0755).To(Equal(os.FileMode(0755)))
+		// Regression test for https://github.com/golang/go/issues/80073:
+		// symlink targets must use platform-specific path separators.
+		verifySymlink := func(linkName, wantedTarget string) {
+			gotTarget, err := os.Readlink(linkName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gotTarget).To(Equal(filepath.FromSlash(wantedTarget)))
 		}
+
+		verifySymlink(filepath.Join(extractionDest, "some-symlink"), "some-file")
+		verifySymlink(filepath.Join(extractionDest, "symlink-dir", "relative-symlink"), "../some-file")
+		verifySymlink(filepath.Join(extractionDest, "symlink-dir", "absolute-symlink"), "/some-file")
+		verifySymlink(filepath.Join(extractionDest, "symlink-dir", "relative-dir-symlink"), "../nonempty-dir")
 	}
 
 	Context("when 'tar' is on the PATH", func() {


### PR DESCRIPTION
pci-4898 goarchive tarfs regression tests

After many, many discussions and attempts, I think I finally nailed it with this one :)

Originally, I tried:
- add regression tests to baggage claim https://github.com/Pix4D/concourse/pull/826 
- add 2 new tests in go-archive/tarfs/extract_test.go that actually resolve the symlinks using `os.ReadFile`: https://github.com/Pix4D/concourse/commit/087624d5076e6265ad9e9420a83f142c0e775232

While both commits would actually work, in both cases, something didn't feel right.

Hence, I went back to the original issues and PRs, to first realize that already:
https://github.com/concourse/concourse/pull/9601

already (partially) added "regression tests" for: https://github.com/concourse/concourse/issues/9597 

I say partially because it added:
```go
		{
			Name: "./symlink-dir/relative-symlink",
			Link: "../some-file",
			Mode: 0755,
		},
		{
			Name: "./symlink-dir/absolute-symlink",
			Link: "/some-file",
			Mode: 0755,
		},
```
to the `archiveFiles` fixture, but did not add any `Expect` check on them. Even though the fact that  `tarfs.Extract` succeeded with them is good enough evidence (at least on linux, where these tests were running). Now, since in the CI (both Pix4D and upstream) we run these tests also on Windows, combined with the checks we do on all symlinks in this archiveFiles fixture: https://github.com/Pix4D/concourse/commit/595b6034ef4c54edd937895a4da95a3b949b0438 is sufficient to catch any potential issue with this code on any platform.

Additionally, I abandoned the idea of resolving the symlinks by using `os.ReadFile` because it didn't feel right (it can't work for absolute symlinks, and it is perfectly valid to have dangling symlinks).  We can actually keep it much simpler and just add the same check I did to report:  https://github.com/golang/go/issues/80073 (the actual bug). The only things that are important are that written symlink target metadata is valid on a given platform

Finally, I just extended all of this with a directory-type symlink since we saw issues with it on Windows 2019
https://github.com/Pix4D/concourse/commit/6f04966a78dddacb46edd5faa5284c204414b692

How can we verify that these tests actually catch what they are supposed to?

Just changing:
```go
- err = root.Symlink(filepath.FromSlash(header.Linkname), filePath)
+ err = root.Symlink(header.Linkname, filePath)
```
in production code make this tests fail on Windows, and passing on Linux.
