### PR TITLE
go-archives: symlink extraction attack tests

### DIFF
--- a/go-archive/tarfs/extract_test.go
+++ b/go-archive/tarfs/extract_test.go
@@ -252,3 +252,135 @@ var _ = Describe("ExtractEntry", func() {
 		})
 	})
 })
+
+var _ = Describe("Extract will not create paths outside the specified directory", func() {
+	var (
+		extractionDest string
+		outside        string
+
+		archive archivetest.Archive
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		extractionDest, err = os.MkdirTemp("", "extract-dest")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Stands in for a location outside the extraction root, e.g.
+		// the user's home directory on Unix or C:\Users\... on Windows. Because
+		// it comes from the OS temp dir it is always an absolute, platform-native
+		// path, so these specs exercise the attack on Unix and Windows alike.
+		outside, err = os.MkdirTemp("", "extract-outside")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Set PATH to a temporary directory to ensure that the tar executable
+		// will not be found. The directory must exist, so that the lookup fails
+		// identically on every platform. GinkgoT().Setenv will restore PATH after
+		// the spec.
+		GinkgoT().Setenv("PATH", GinkgoT().TempDir())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(extractionDest)
+		os.RemoveAll(outside)
+	})
+
+	Context("when a directory symlink escapes via an absolute path", func() {
+		BeforeEach(func() {
+			archive = archivetest.Archive{
+				{Name: "escape", Link: filepath.ToSlash(outside)},
+				{Name: "escape/evil.txt", Body: "pwned"},
+			}
+		})
+
+		It("refuses to create the file outside the destination", func() {
+			src, err := archive.TarStream()
+			Expect(err).NotTo(HaveOccurred())
+
+			extractionErr := tarfs.Extract(src, extractionDest)
+			Expect(extractionErr).To(HaveOccurred())
+
+			escapedFile := filepath.Join(outside, "evil.txt")
+			_, statErr := os.Stat(escapedFile)
+			Expect(os.IsNotExist(statErr)).To(BeTrue(),
+				"extraction escaped and wrote %q outside the destination", escapedFile)
+		})
+	})
+
+	Context("when a directory symlink escapes via a relative .. path", func() {
+		BeforeEach(func() {
+			escapeLink, err := filepath.Rel(extractionDest, outside)
+			Expect(err).NotTo(HaveOccurred())
+
+			archive = archivetest.Archive{
+				{Name: "escape", Link: filepath.ToSlash(escapeLink)},
+				{Name: "escape/evil.txt", Body: "pwned"},
+			}
+		})
+
+		It("refuses to create the file outside the destination", func() {
+			src, err := archive.TarStream()
+			Expect(err).NotTo(HaveOccurred())
+
+			extractionErr := tarfs.Extract(src, extractionDest)
+			Expect(extractionErr).To(HaveOccurred())
+
+			escapedFile := filepath.Join(outside, "evil.txt")
+			_, statErr := os.Stat(escapedFile)
+			Expect(os.IsNotExist(statErr)).To(BeTrue(),
+				"extraction escaped and wrote %q outside the destination", escapedFile)
+		})
+	})
+
+	Context("when a file symlink escapes via an absolute path", func() {
+		BeforeEach(func() {
+			target := filepath.Join(outside, "evil.txt")
+
+			archive = archivetest.Archive{
+				{Name: "escape", Link: filepath.ToSlash(target)},
+				{Name: "escape", Body: "pwned"},
+			}
+		})
+
+		It("refuses to write the file outside the destination", func() {
+			src, err := archive.TarStream()
+			Expect(err).NotTo(HaveOccurred())
+
+			extractionErr := tarfs.Extract(src, extractionDest)
+			Expect(extractionErr).To(HaveOccurred())
+
+			target := filepath.Join(outside, "evil.txt")
+			_, statErr := os.Stat(target)
+			Expect(os.IsNotExist(statErr)).To(BeTrue(),
+				"extraction escaped and wrote %q outside the destination", target)
+		})
+	})
+
+	Context("when a file symlink escapes via a relative .. path", func() {
+		BeforeEach(func() {
+			target := filepath.Join(outside, "evil.txt")
+
+			escapeLink, err := filepath.Rel(extractionDest, target)
+			Expect(err).NotTo(HaveOccurred())
+
+			archive = archivetest.Archive{
+				{Name: "escape", Link: filepath.ToSlash(escapeLink)},
+				{Name: "escape", Body: "pwned"},
+			}
+		})
+
+		It("refuses to write the file outside the destination", func() {
+			src, err := archive.TarStream()
+			Expect(err).NotTo(HaveOccurred())
+
+			extractionErr := tarfs.Extract(src, extractionDest)
+			Expect(extractionErr).To(HaveOccurred())
+
+			target := filepath.Join(outside, "evil.txt")
+			_, statErr := os.Stat(target)
+			Expect(os.IsNotExist(statErr)).To(BeTrue(),
+				"extraction escaped and wrote %q outside the destination", target)
+		})
+	})
+})


### PR DESCRIPTION
go-archives: symlink extraction attack tests

Add some more tests mimicking the symlink extraction attack. 

Goal: show the value of using `os.Root` :) and prevent anyone from removing it by mistake without first understanding its value, e.g., it prevents reverting https://github.com/concourse/concourse/pull/9601

I would also say that this tests are evidence that the security issue reported in: https://github.com/concourse/concourse/pull/9486 was actually addressed.